### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ mkdir .devcontainer
 git submodule add https://github.com/containercraft/konductor .github/konductor
 git submodule update --init .github/konductor
 git submodule update --remote --merge .github/konductor
-rsync -av .github/konductor/devcontainer/* .devcontainer
+rsync -av .github/konductor/.devcontainer/* .devcontainer
 ```
 
 To update the devcontainer submodule in consuming repos:


### PR DESCRIPTION
Seems like the devcontainer folder is under .devcontainer

```
rsync -av .github/konductor/devcontainer/* .devcontainer
sending incremental file list
rsync: [sender] change_dir "/home/leon/graphq-stuff/.github/konductor/devcontainer" failed: No such file or directory (2)

sent 19 bytes  received 12 bytes  62.00 bytes/sec
total size is 0  speedup is 0.00
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1336) [sender=3.2.7]
```

```
rsync -av .github/konductor/.devcontainer/* .devcontainer
sending incremental file list
Dockerfile
README.md
```